### PR TITLE
Remove sending server api version

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -185,7 +185,6 @@ func (d *Datasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRe
 		return res, nil
 	}
 
-	serverAPI := options.ServerAPI(options.ServerAPIVersion1)
 	var uri string
 
 	if config.AuthMethod == "auth-none" {


### PR DESCRIPTION
Fix https://github.com/haohanyang/mongodb-datasource/issues/3 : Remove sending server API version to support older versions of MongoDB