### PR TITLE
fix(models): avoid bsoncore Value.String() roundtrip for raw JSON

### DIFF
--- a/pkg/models/utils.go
+++ b/pkg/models/utils.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -11,10 +10,24 @@ func pointer[K any](val K) *K {
 	return &val
 }
 
+// rawArrayToJson serializes a BSON array RawValue to a JSON string.
+//
+// We deliberately do NOT call value.String() to obtain the extended-JSON
+// form. value.String() goes through x/bsonx/bsoncore.formatDouble, which
+// has a bug: it appends ".0" to a scientific-notation float like "2E-05",
+// producing "2E-05.0" and breaking strconv.ParseFloat in the subsequent
+// UnmarshalExtJSON step. The canonical formatDouble in
+// bson/bsonrw/extjson_writer.go (used by bson.MarshalExtJSON) does not
+// have this bug, so we route the BSON-to-extJSON conversion through there.
 func rawArrayToJson(value bson.RawValue) (string, error) {
-	var bsonDoc bson.M
-	err := bson.UnmarshalExtJSON([]byte(fmt.Sprintf(`{"data":%s}`, value.String())), true, &bsonDoc)
+	wrap := bson.D{{Key: "data", Value: value}}
+	extJSON, err := bson.MarshalExtJSON(wrap, true, false)
 	if err != nil {
+		return "", err
+	}
+
+	var bsonDoc bson.M
+	if err := bson.UnmarshalExtJSON(extJSON, true, &bsonDoc); err != nil {
 		return "", err
 	}
 
@@ -25,11 +38,16 @@ func rawArrayToJson(value bson.RawValue) (string, error) {
 	return string(rawBytes), nil
 }
 
+// rawDocToJson serializes a BSON embedded-document RawValue to a JSON
+// string. See rawArrayToJson for why we avoid value.String().
 func rawDocToJson(value bson.RawValue) (string, error) {
-	var bsonMap bson.M
-
-	err := bson.UnmarshalExtJSON([]byte(value.String()), true, &bsonMap)
+	extJSON, err := bson.MarshalExtJSON(bson.Raw(value.Value), true, false)
 	if err != nil {
+		return "", err
+	}
+
+	var bsonMap bson.M
+	if err := bson.UnmarshalExtJSON(extJSON, true, &bsonMap); err != nil {
 		return "", err
 	}
 

--- a/pkg/models/utils_test.go
+++ b/pkg/models/utils_test.go
@@ -1,0 +1,63 @@
+package models
+
+import (
+	"strings"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// Regression for the bsoncore formatDouble bug: rendering a BSON document
+// containing a double like 2e-05 used to go through value.String(), which
+// produced {"$numberDouble":"2E-05.0"} (note the trailing ".0" after "E-05")
+// and then failed to round-trip through bson.UnmarshalExtJSON with
+//
+//	error decoding key X: strconv.ParseFloat: parsing "2E-05.0": invalid syntax
+func TestRawDocToJson_SmallScientificDoubleRoundTrips(t *testing.T) {
+	docBytes, err := bson.Marshal(bson.M{
+		"sub": bson.M{
+			"value":       2e-05,
+			"lower_value": 0.000019,
+			"upper_value": 5e-200,
+			"integer_d":   1.0,
+			"plain":       0.123,
+		},
+	})
+	if err != nil {
+		t.Fatalf("bson.Marshal: %v", err)
+	}
+
+	rv := bson.Raw(docBytes).Lookup("sub")
+	out, err := rawDocToJson(rv)
+	if err != nil {
+		t.Fatalf("rawDocToJson returned error for small double: %v", err)
+	}
+	for _, want := range []string{`"value":0.00002`, `"lower_value":0.000019`, `"upper_value":5e-200`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output %q missing %q", out, want)
+		}
+	}
+	if strings.Contains(out, "E-05.0") || strings.Contains(out, ".0e") {
+		t.Errorf("output %q contains malformed scientific-notation float", out)
+	}
+}
+
+func TestRawArrayToJson_SmallScientificDoubleRoundTrips(t *testing.T) {
+	docBytes, err := bson.Marshal(bson.M{
+		"arr": bson.A{2e-05, 0.5, 1.0, 1e+200},
+	})
+	if err != nil {
+		t.Fatalf("bson.Marshal: %v", err)
+	}
+
+	rv := bson.Raw(docBytes).Lookup("arr")
+	out, err := rawArrayToJson(rv)
+	if err != nil {
+		t.Fatalf("rawArrayToJson returned error: %v", err)
+	}
+	for _, want := range []string{"0.00002", "0.5", "1e+200"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output %q missing %q", out, want)
+		}
+	}
+}


### PR DESCRIPTION
rawDocToJson and rawArrayToJson previously rendered BSON values to extended JSON via value.String() and then re-parsed with bson.UnmarshalExtJSON. value.String() is implemented in go.mongodb.org/mongo-driver's x/bsonx/bsoncore package, whose formatDouble appends ".0" to a formatted float when no decimal point is present, but does NOT skip that branch when the formatted form contains 'E' (scientific notation). For values like 2e-05 this produces '{"$numberDouble":"2E-05.0"}', which the subsequent UnmarshalExtJSON rejects with:

  error decoding key X: strconv.ParseFloat: parsing "2E-05.0": invalid syntax

(The duplicate formatDouble in bson/bsonrw/extjson_writer.go has the correct 'E' check; only the bsoncore copy is buggy.)

Switch both helpers to round-trip through bson.MarshalExtJSON instead, which uses the correct extjson_writer.go::formatDouble. Output shape is preserved, so downstream consumers (column.go's rectify path and the existing query tests covering embedded-doc/array fields) are unaffected.

Includes regression tests for small scientific-notation doubles in both embedded documents and arrays.