### PR TITLE
feat: Add support for LDAP authentication (PLAIN mechanism)

### DIFF
--- a/pkg/plugin/mongo_opts.go
+++ b/pkg/plugin/mongo_opts.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"errors"
 	"net/url"
+	"strings"
 
 	"github.com/haohanyang/mongodb-datasource/pkg/models"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -31,6 +32,12 @@ func buildMongoOpts(config *models.PluginSettings) (*options.ClientOptions, erro
 	return opts, nil
 }
 
+// isPlainAuth checks if PLAIN authentication mechanism is specified in connection options
+func isPlainAuth(connectionOptions string) bool {
+	lowerOpts := strings.ToLower(connectionOptions)
+	return strings.Contains(lowerOpts, "authmechanism=plain")
+}
+
 func setAuth(config *models.PluginSettings, opts *options.ClientOptions) error {
 	if config.AuthMethod == mongoAuthUsernamePassword {
 		if config.Username == "" || config.Secrets == nil || config.Secrets.Password == "" {
@@ -42,7 +49,16 @@ func setAuth(config *models.PluginSettings, opts *options.ClientOptions) error {
 			Password: config.Secrets.Password,
 		}
 
-		if config.AuthDatabase != "" {
+		// Check if PLAIN (LDAP) authentication is requested
+		if isPlainAuth(config.ConnectionOptions) {
+			cred.AuthMechanism = "PLAIN"
+			// For PLAIN/LDAP auth, default to $external if no auth database specified
+			if config.AuthDatabase != "" {
+				cred.AuthSource = config.AuthDatabase
+			} else {
+				cred.AuthSource = "$external"
+			}
+		} else if config.AuthDatabase != "" {
 			cred.AuthSource = config.AuthDatabase
 		}
 
@@ -79,6 +95,14 @@ func setUri(config *models.PluginSettings, opts *options.ClientOptions) error {
 
 	if config.ConnectionStringScheme == connstring.SchemeMongoDBSRV {
 		u.Scheme = connstring.SchemeMongoDBSRV
+	}
+
+	// For PLAIN (LDAP) authentication, credentials must be included in the URI
+	// because the MongoDB driver validates this when authMechanism=PLAIN is specified
+	if isPlainAuth(config.ConnectionOptions) && config.AuthMethod == mongoAuthUsernamePassword {
+		if config.Username != "" && config.Secrets != nil && config.Secrets.Password != "" {
+			u.User = url.UserPassword(config.Username, config.Secrets.Password)
+		}
 	}
 
 	// Remove starting ? in connection options

--- a/pkg/plugin/mongo_opts_test.go
+++ b/pkg/plugin/mongo_opts_test.go
@@ -197,6 +197,84 @@ func TestSetUri(t *testing.T) {
 			t.Errorf("expected connection string %s, got %s", expected, opts.GetURI())
 		}
 	})
+
+	t.Run("should include credentials in URI for PLAIN auth", func(t *testing.T) {
+		opts := options.Client()
+		config := &models.PluginSettings{
+			Host:              "localhost:27017",
+			Database:          "test",
+			AuthMethod:        mongoAuthUsernamePassword,
+			Username:          "ldapuser",
+			ConnectionOptions: "authMechanism=PLAIN&authSource=$external",
+			Secrets: &models.SecretPluginSettings{
+				Password: "ldappass",
+			},
+		}
+
+		err := setUri(config, opts)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		uri := opts.GetURI()
+		// Check that credentials are included in the URI
+		if !strings.Contains(uri, "ldapuser:ldappass@") {
+			t.Errorf("expected URI to contain credentials, got %s", uri)
+		}
+		// Check that authMechanism is preserved
+		if !strings.Contains(uri, "authMechanism=PLAIN") {
+			t.Errorf("expected URI to contain authMechanism=PLAIN, got %s", uri)
+		}
+	})
+
+	t.Run("should URL-encode special characters in credentials for PLAIN auth", func(t *testing.T) {
+		opts := options.Client()
+		config := &models.PluginSettings{
+			Host:              "localhost:27017",
+			Database:          "test",
+			AuthMethod:        mongoAuthUsernamePassword,
+			Username:          "user@domain.com",
+			ConnectionOptions: "authMechanism=PLAIN&authSource=$external",
+			Secrets: &models.SecretPluginSettings{
+				Password: "p@ss:word/test",
+			},
+		}
+
+		err := setUri(config, opts)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		uri := opts.GetURI()
+		// Check that special characters are URL-encoded
+		if !strings.Contains(uri, "user%40domain.com") {
+			t.Errorf("expected URI to contain URL-encoded username, got %s", uri)
+		}
+	})
+
+	t.Run("should not include credentials in URI for non-PLAIN auth", func(t *testing.T) {
+		opts := options.Client()
+		config := &models.PluginSettings{
+			Host:       "localhost:27017",
+			Database:   "test",
+			AuthMethod: mongoAuthUsernamePassword,
+			Username:   "testuser",
+			Secrets: &models.SecretPluginSettings{
+				Password: "testpass",
+			},
+		}
+
+		err := setUri(config, opts)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		uri := opts.GetURI()
+		// Check that credentials are NOT included in the URI for regular auth
+		if strings.Contains(uri, "testuser") || strings.Contains(uri, "testpass") {
+			t.Errorf("expected URI to NOT contain credentials for non-PLAIN auth, got %s", uri)
+		}
+	})
 }
 
 func TestSetAuth(t *testing.T) {
@@ -274,6 +352,103 @@ func TestSetAuth(t *testing.T) {
 
 		if auth.AuthSource != "$external" {
 			t.Errorf("expected auth source %s, got %s", "$external", auth.AuthSource)
+		}
+	})
+
+	t.Run("should set PLAIN auth with default $external source", func(t *testing.T) {
+		opts := options.Client()
+		config := &models.PluginSettings{
+			Host:              "localhost:27017",
+			AuthMethod:        mongoAuthUsernamePassword,
+			Database:          "test",
+			Username:          "ldapuser",
+			ConnectionOptions: "authMechanism=PLAIN&authSource=$external",
+			Secrets: &models.SecretPluginSettings{
+				Password: "ldappass",
+			},
+		}
+
+		err := setAuth(config, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		auth := opts.Auth
+
+		if auth == nil {
+			t.Fatalf("expected auth to be set, got nil")
+		}
+		if auth.Username != "ldapuser" {
+			t.Errorf("expected username %s, got %s", "ldapuser", auth.Username)
+		}
+		if auth.Password != "ldappass" {
+			t.Errorf("expected password %s, got %s", "ldappass", auth.Password)
+		}
+		if auth.AuthMechanism != "PLAIN" {
+			t.Errorf("expected auth mechanism %s, got %s", "PLAIN", auth.AuthMechanism)
+		}
+		if auth.AuthSource != "$external" {
+			t.Errorf("expected auth source %s, got %s", "$external", auth.AuthSource)
+		}
+	})
+
+	t.Run("should set PLAIN auth with custom auth database", func(t *testing.T) {
+		opts := options.Client()
+		config := &models.PluginSettings{
+			Host:              "localhost:27017",
+			AuthMethod:        mongoAuthUsernamePassword,
+			Database:          "test",
+			Username:          "ldapuser",
+			AuthDatabase:      "customdb",
+			ConnectionOptions: "authMechanism=PLAIN",
+			Secrets: &models.SecretPluginSettings{
+				Password: "ldappass",
+			},
+		}
+
+		err := setAuth(config, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		auth := opts.Auth
+
+		if auth == nil {
+			t.Fatalf("expected auth to be set, got nil")
+		}
+		if auth.AuthMechanism != "PLAIN" {
+			t.Errorf("expected auth mechanism %s, got %s", "PLAIN", auth.AuthMechanism)
+		}
+		if auth.AuthSource != "customdb" {
+			t.Errorf("expected auth source %s, got %s", "customdb", auth.AuthSource)
+		}
+	})
+
+	t.Run("should detect PLAIN auth case-insensitively", func(t *testing.T) {
+		opts := options.Client()
+		config := &models.PluginSettings{
+			Host:              "localhost:27017",
+			AuthMethod:        mongoAuthUsernamePassword,
+			Database:          "test",
+			Username:          "ldapuser",
+			ConnectionOptions: "AUTHMECHANISM=plain&authSource=$external",
+			Secrets: &models.SecretPluginSettings{
+				Password: "ldappass",
+			},
+		}
+
+		err := setAuth(config, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		auth := opts.Auth
+
+		if auth == nil {
+			t.Fatalf("expected auth to be set, got nil")
+		}
+		if auth.AuthMechanism != "PLAIN" {
+			t.Errorf("expected auth mechanism %s, got %s", "PLAIN", auth.AuthMechanism)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

This PR adds support for MongoDB LDAP authentication using the PLAIN authentication mechanism.

## Problem

The plugin fails to connect to MongoDB when using LDAP authentication with `authMechanism=PLAIN`. The error message is:

```
error validating uri: username required for PLAIN
```

This occurs because when `authMechanism=PLAIN` is specified in connection options, the MongoDB Go driver validates that credentials are included in the connection URI itself, not just set via the Auth options.

## Solution

### Changes in `pkg/plugin/mongo_opts.go`:

1. **Added `isPlainAuth()` helper function** - Detects if PLAIN authentication is specified in connection options (case-insensitive)

2. **Updated `setAuth()` function** - When PLAIN auth is detected:
   - Sets `AuthMechanism` to "PLAIN"
   - Defaults `AuthSource` to "$external" (required for LDAP)
   - Respects custom auth database if specified

3. **Updated `setUri()` function** - When PLAIN auth is detected:
   - Includes URL-encoded username:password in the connection URI
   - This satisfies the MongoDB driver's validation requirement

### Tests Added in `pkg/plugin/mongo_opts_test.go`:
- Test for PLAIN auth with default `$external` source
- Test for PLAIN auth with custom auth database
- Test for case-insensitive detection of PLAIN mechanism
- Test for credentials in URI for PLAIN auth
- Test for URL-encoding special characters in credentials
- Test to verify non-PLAIN auth doesn't include credentials in URI

## Usage

Users can now connect to MongoDB with LDAP authentication by:
1. Selecting "Username/Password" authentication
2. Entering their LDAP username and password
3. Adding `authMechanism=PLAIN&authSource=$external` to connection string options

## Testing

The fix has been verified with unit tests. The same MongoDB instance that was failing now connects successfully using the PLAIN mechanism.