### PR TITLE
fix(plugin): interpolate time macros in backend for alert rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Grafana global time macros (`$__from`/`$__to`, incl. `:date`, `:date:iso`, `:date:seconds`) are now interpolated in the backend, so queries using them work in alert rules. Previously these were only substituted in the frontend, so alert evaluation (which runs server-side) failed with `Failed to unmarshal JsonExt`.
+
 ## 0.5.0 - 2026-03-29
 ⚠️ **This version contains breaking changes**
 ### Added

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -179,6 +179,12 @@ func (d *Datasource) query(ctx context.Context, query backend.DataQuery) backend
 		return backend.ErrDataResponse(backend.StatusBadRequest, "Collection field is required")
 	}
 
+	// Grafana interpolates global time macros ($__from/$__to) only in the
+	// frontend, which alert-rule evaluation bypasses. Interpolate them here so
+	// alerts work; this is a no-op for dashboard/Explore queries that were
+	// already substituted client-side.
+	qm.QueryText = interpolateTimeMacros(qm.QueryText, query.TimeRange)
+
 	var pipeline []bson.D
 
 	err = bson.UnmarshalExtJSON([]byte(qm.QueryText), false, &pipeline)

--- a/pkg/plugin/macros.go
+++ b/pkg/plugin/macros.go
@@ -1,0 +1,66 @@
+package plugin
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+// timeMacroRegex matches Grafana global time macros in either bare ($__from) or
+// braced (${__from:date:seconds}) form.
+//
+//	sub[1] = bare field ("from"/"to"), empty for braced form
+//	sub[2] = braced field ("from"/"to"), empty for bare form
+//	sub[3] = ":date" when the date modifier is present, empty otherwise
+//	sub[4] = format token after :date ("seconds", "iso", or a custom layout)
+var timeMacroRegex = regexp.MustCompile(`\$(?:__(from|to)\b|\{__(from|to)(:date)?(?::([^}]+))?\})`)
+
+// interpolateTimeMacros replaces Grafana global time macros ($__from / $__to and
+// their :date / :date:iso / :date:seconds variants) with values derived from the
+// query time range.
+//
+// Grafana only interpolates these macros in the frontend (see
+// MongoDBDataSource.applyTemplateVariables). Alert-rule evaluation runs entirely
+// server-side and never calls that code, so the raw "${__from...}" text reaches
+// the backend and breaks Extended JSON parsing on the leading "$". This mirrors
+// the frontend's raw text substitution (no added quotes), so it is a no-op for
+// dashboard/Explore queries where the tokens were already replaced.
+func interpolateTimeMacros(queryText string, tr backend.TimeRange) string {
+	return timeMacroRegex.ReplaceAllStringFunc(queryText, func(match string) string {
+		sub := timeMacroRegex.FindStringSubmatch(match)
+
+		bare := sub[1]
+		braced := sub[2]
+		hasDate := sub[3] != ""
+		format := sub[4]
+
+		field := bare
+		if field == "" {
+			field = braced
+		}
+
+		t := tr.From
+		if field == "to" {
+			t = tr.To
+		}
+
+		// Bare $__from / $__to and braced ${__from} without :date -> epoch ms.
+		if bare != "" || !hasDate {
+			return strconv.FormatInt(t.UnixMilli(), 10)
+		}
+
+		switch strings.ToLower(format) {
+		case "seconds":
+			return strconv.FormatInt(t.Unix(), 10)
+		case "", "iso":
+			// ${__from:date} and ${__from:date:iso} -> ISO 8601 in UTC.
+			return t.UTC().Format("2006-01-02T15:04:05.000Z07:00")
+		default:
+			// Custom momentjs layouts aren't supported server-side; leave the
+			// macro untouched rather than emit a wrong value.
+			return match
+		}
+	})
+}

--- a/pkg/plugin/macros_test.go
+++ b/pkg/plugin/macros_test.go
@@ -1,0 +1,48 @@
+package plugin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+func TestInterpolateTimeMacros(t *testing.T) {
+	from := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	to := time.Date(2024, 1, 2, 4, 5, 6, 0, time.UTC)
+	tr := backend.TimeRange{From: from, To: to}
+
+	fromSec := "1704164645"
+	toSec := "1704168306"
+	fromMs := "1704164645000"
+	fromISO := "2024-01-02T03:04:05.000Z"
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"seconds", `${__from:date:seconds}`, fromSec},
+		{"seconds to", `${__to:date:seconds}`, toSec},
+		{"bare ms", `$__from`, fromMs},
+		{"braced ms", `${__from}`, fromMs},
+		{"iso explicit", `${__from:date:iso}`, fromISO},
+		{"iso default", `${__from:date}`, fromISO},
+		{"embedded in json", `{"$gt":{"$timestamp":{"t":${__from:date:seconds},"i":0}}}`,
+			`{"$gt":{"$timestamp":{"t":` + fromSec + `,"i":0}}}`},
+		{"both", `[${__from:date:seconds},${__to:date:seconds}]`, "[" + fromSec + "," + toSec + "]"},
+		{"custom layout untouched", `${__from:date:YYYY-MM-DD}`, `${__from:date:YYYY-MM-DD}`},
+		{"unrelated operators untouched", `{"$group":{"$sum":1}}`, `{"$group":{"$sum":1}}`},
+		{"custom vars untouched", `${myVar} $__from_oid ${__local_from} ${__to_oid}`, `${myVar} $__from_oid ${__local_from} ${__to_oid}`},
+		{"no macros", `{"a":1}`, `{"a":1}`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := interpolateTimeMacros(c.in, tr)
+			if got != c.want {
+				t.Errorf("interpolateTimeMacros(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #99

## Problem

Grafana global time macros (`$__from` / `$__to` and their `:date` / `:date:iso` / `:date:seconds` variants) are only substituted in the frontend (`MongoDBDataSource.applyTemplateVariables` in `src/datasource.ts`). Alert-rule evaluation runs entirely server-side and never calls that code, so the raw `${__from...}` text reaches `bson.UnmarshalExtJSON` in the backend and fails:

```
Failed to unmarshal JsonExt: ... invalid JSON input. Position: N. Character: $
```

The same pipelines work in Explore and dashboard panels because the frontend interpolates the macros there.

## Fix

Interpolate the time macros in the backend query path, using the query's `TimeRange` (already carried on every `backend.DataQuery`), before parsing the pipeline.

- New `pkg/plugin/macros.go` — `interpolateTimeMacros` handles `$__from` / `$__to` in bare and braced forms:
  - bare `$__from` / `${__from}` → epoch **milliseconds**
  - `${__from:date:seconds}` → epoch **seconds**
  - `${__from:date}` / `${__from:date:iso}` → **ISO 8601** (UTC)
  - unknown/custom momentjs layouts are left untouched rather than emitting a wrong value
- Substitution mirrors the frontend's raw text output (no added quotes), so it is a **no-op** for dashboard/Explore queries that were already interpolated client-side.
- Wired into `Datasource.query()` right before `bson.UnmarshalExtJSON`.

## Scope / notes

- Covers Grafana's built-in `$__from` / `$__to` — this resolves the reported error for both variants in the issue (`$numberLong: "$__from"` and `${__from:date:iso}`).
- The plugin's custom frontend-only variables (`$__from_oid`, `$__to_oid`, `$__local_from`, `$__local_to`, `$__dateBucketCount`) are still not available on the alert path. Left out to keep this change focused; happy to follow up if wanted.

## Tests

- `pkg/plugin/macros_test.go` — table test covering seconds/ms/iso forms, embedding in JSON, custom-layout pass-through, and that unrelated `$` operators and custom variables are untouched.
- `go test ./pkg/plugin -run TestInterpolateTimeMacros` and `go vet ./pkg/plugin` pass.

Generated with Claude Code